### PR TITLE
ISSUE-4 Error building 1.13.5 and 1.14.0 - chown: invalid user: ‘tomcat:tomcat’

### DIFF
--- a/hyrax-1.13.5/olfs/Dockerfile
+++ b/hyrax-1.13.5/olfs/Dockerfile
@@ -8,6 +8,9 @@ MAINTAINER support@opendap.org
 
 USER root
 
+RUN apt-get update && \
+    apt-get install -y procps
+
 #
 # The --build-arg USE_NCWMS can be set to "true" in order to 
 # add the ncWMS application to the build.
@@ -57,7 +60,7 @@ RUN set -e \
 # Fix ownership and access permissions
 RUN set -e \
     && mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
-    && chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
+    #&& chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
     && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs 
 
 
@@ -89,7 +92,7 @@ EXPOSE 8080 8443
 
 # Fix ownership and access permissions
 RUN mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs && \
-    chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs && \
+    #chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs && \
     chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs
 
 ##########################################################################################

--- a/hyrax-1.14.0/olfs/Dockerfile
+++ b/hyrax-1.14.0/olfs/Dockerfile
@@ -8,6 +8,9 @@ MAINTAINER support@opendap.org
 
 USER root
 
+RUN apt-get update && \
+    apt-get install -y procps
+
 #
 # The --build-arg USE_NCWMS can be set to "true" in order to 
 # add the ncWMS application to the build.
@@ -57,7 +60,7 @@ RUN set -e \
 # Fix ownership and access permissions
 RUN set -e \
     && mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
-    && chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
+    #&& chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
     && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs 
 
 
@@ -89,7 +92,7 @@ EXPOSE 8080 8443
 
 # Fix ownership and access permissions
 RUN mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs && \
-    chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs && \
+    #chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs && \
     chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs
 
 ##########################################################################################


### PR DESCRIPTION
Hi Folks, I commented out the offending tomcat user entries, if you would like me to remove the line entries then I can go ahead.