### PR TITLE
Regression Tests For Docker Images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 
 stages:
   - name: build
-    if:  branch = master OR branch = reg_tests
+    if:  branch = master
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
 
 stages:
   - name: build
-    if:  branch = master
+    if:  branch = master OR branch = reg_tests
 
 jobs:
   include:

--- a/hyrax-1.16.1/hyrax/Dockerfile
+++ b/hyrax-1.16.1/hyrax/Dockerfile
@@ -233,6 +233,9 @@ RUN set -e \
     && autoreconf -vif \
     && ./configure
 
+# In order to get the executable "testsuite" to build we have to run
+# "make check" But that will fail at build time so the "make check" call
+# ends up pretty tortured to avoid a build error.
 RUN set -e \
     && cd ${TEST_INSTALL_DIR} \
     && make check -k | tee /dev/null > mk.log 2>&1 \

--- a/hyrax-1.16.1/hyrax/Dockerfile
+++ b/hyrax-1.16.1/hyrax/Dockerfile
@@ -61,12 +61,12 @@ RUN set -e && \
 # Update and install the needful.
 RUN set -e \
     && yum -y install \
-       tomcat \
-       unzip  \
-       which \
-       autoconf \
-       automake \
-       git \
+            tomcat \
+            unzip  \
+            which \
+            autoconf \
+            automake \
+            git \
     && yum -y update \
     && yum clean all 
 
@@ -75,24 +75,15 @@ ENV CATALINA_HOME /usr/share/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 RUN echo "CATALINA_HOME: $CATALINA_HOME"
 
-
-################################################################
-# Set this to -k to convince curl to get the stuff when there
-# expired TLS certs.
-#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
-ENV ALLOW_EXPIRED=""
-###############################################################
-
-
 ################################################################
 # Install the OPeNDAP security public key.
 #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 # TODO: We should get this from a well known key-server instead.
-#RUN echo "Adding OPeNDAP Public Security Key"
+RUN echo "Adding OPeNDAP Public Security Key"
 ENV OPENDAP_PUBLIC_KEY_FILE="security_at_opendap.org.pub.asc"
 ENV OPENDAP_PUBLIC_KEY_URL="https://www.opendap.org/${OPENDAP_PUBLIC_KEY_FILE}"
 RUN set -e \
-    && curl $ALLOW_EXPIRED -s $OPENDAP_PUBLIC_KEY_URL > $OPENDAP_PUBLIC_KEY_FILE \
+    && curl -s $OPENDAP_PUBLIC_KEY_URL > $OPENDAP_PUBLIC_KEY_FILE \
     && gpg --import $OPENDAP_PUBLIC_KEY_FILE
 ###############################################################
 
@@ -100,47 +91,51 @@ RUN set -e \
 ###############################################################
 # RELEASE URLs
 #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
-
 ENV LIBDAP_RPM="https://www.opendap.org/pub/binary/hyrax-${HYRAX_VERSION}/centos-7.x/libdap-${LIBDAP_VERSION}.el7.x86_64.rpm"
 ENV BES_RPM="https://www.opendap.org/pub/binary/hyrax-${HYRAX_VERSION}/centos-7.x/bes-${BES_VERSION}.static.el7.x86_64.rpm"
 ENV OLFS_WAR_URL="https://www.opendap.org/pub/olfs/olfs-${OLFS_VERSION}-webapp.tgz"
+###############################################################
+
 
 ###############################################################
 # Retrieve, verify, and install Libdap
 #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, verifying, and installing libdap. rpm: $LIBDAP_RPM" \
-    && curl $ALLOW_EXPIRED -s $LIBDAP_RPM > ./libdap.rpm \
-    && curl $ALLOW_EXPIRED -s $LIBDAP_RPM.sig > ./libdap.rpm.sig \
+    && curl -s $LIBDAP_RPM > ./libdap.rpm \
+    && curl -s $LIBDAP_RPM.sig > ./libdap.rpm.sig \
     && gpg -v --verify ./libdap.rpm.sig ./libdap.rpm \
     && ls -l ./libdap* \
     && yum -y install ./libdap.rpm \
     && rm -f libdap.*
 
 # gpg --keyserver certserver.pgp.com --recv-keys 
+###############################################################
 
 
-################################################################
+###############################################################
 # Retrieve, verify, and install the BES
 #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, verifying, and installing besd. rpm: $BES_RPM" \
-    && curl $ALLOW_EXPIRED -s ${BES_RPM} > ./bes.rpm \
-    && curl $ALLOW_EXPIRED -s ${BES_RPM}.sig > ./bes.rpm.sig \
+    && curl -s ${BES_RPM} > ./bes.rpm \
+    && curl -s ${BES_RPM}.sig > ./bes.rpm.sig \
     && gpg -v --verify ./bes.rpm.sig ./bes.rpm \
     && ls -l ./bes* \
     && yum -y install ./bes.rpm \
     && rm -f bes.*
 
 RUN echo "besdaemon is here: "`which besdaemon`
+###############################################################
+
 
 ################################################################
 # Retrieve, verify, and install the OLFS web application
 #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving And Installing OLFS-${OLFS_VERSION}" \
-    && curl $ALLOW_EXPIRED -sfSL ${OLFS_WAR_URL} > olfs-${OLFS_VERSION}.tgz \
-    && curl $ALLOW_EXPIRED -sfSL ${OLFS_WAR_URL}.sig > olfs-${OLFS_VERSION}.tgz.sig \
+    && curl -sfSL ${OLFS_WAR_URL} > olfs-${OLFS_VERSION}.tgz \
+    && curl -sfSL ${OLFS_WAR_URL}.sig > olfs-${OLFS_VERSION}.tgz.sig \
     && echo "Verifying tarball..." \
     && gpg --verify olfs-${OLFS_VERSION}.tgz.sig olfs-${OLFS_VERSION}.tgz \
     && echo "Unpacking tarball..." \
@@ -154,9 +149,8 @@ RUN set -e \
 RUN set -e \
     && mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
-    && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs
-
-################################################################
+    && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs 
+###############################################################
 
 
 ###############################################################
@@ -212,9 +206,7 @@ RUN set -e \
     && mv /tomcat7-server.xml ${CATALINA_HOME}/conf/server.xml \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/conf/server.xml
 
-################################################################
-
-
+###############################################################
 
 
 ################################################################

--- a/hyrax-1.16.1/hyrax/Dockerfile
+++ b/hyrax-1.16.1/hyrax/Dockerfile
@@ -64,6 +64,9 @@ RUN set -e \
        tomcat \
        unzip  \
        which \
+       autoconf \
+       automake \
+       git \
     && yum -y update \
     && yum clean all 
 
@@ -72,17 +75,31 @@ ENV CATALINA_HOME /usr/share/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 RUN echo "CATALINA_HOME: $CATALINA_HOME"
 
-# Installs the OPeNDAP security public key.
+
+################################################################
+# Set this to -k to convince curl to get the stuff when there
+# expired TLS certs.
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+ENV ALLOW_EXPIRED=""
+###############################################################
+
+
+################################################################
+# Install the OPeNDAP security public key.
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 # TODO: We should get this from a well known key-server instead.
-RUN echo "Adding OPeNDAP Public Security Key"
+#RUN echo "Adding OPeNDAP Public Security Key"
 ENV OPENDAP_PUBLIC_KEY_FILE="security_at_opendap.org.pub.asc"
 ENV OPENDAP_PUBLIC_KEY_URL="https://www.opendap.org/${OPENDAP_PUBLIC_KEY_FILE}"
 RUN set -e \
-    && curl -s $OPENDAP_PUBLIC_KEY_URL > $OPENDAP_PUBLIC_KEY_FILE \
+    && curl $ALLOW_EXPIRED -s $OPENDAP_PUBLIC_KEY_URL > $OPENDAP_PUBLIC_KEY_FILE \
     && gpg --import $OPENDAP_PUBLIC_KEY_FILE
+###############################################################
 
 
+###############################################################
 # RELEASE URLs
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
 ENV LIBDAP_RPM="https://www.opendap.org/pub/binary/hyrax-${HYRAX_VERSION}/centos-7.x/libdap-${LIBDAP_VERSION}.el7.x86_64.rpm"
 ENV BES_RPM="https://www.opendap.org/pub/binary/hyrax-${HYRAX_VERSION}/centos-7.x/bes-${BES_VERSION}.static.el7.x86_64.rpm"
@@ -90,10 +107,11 @@ ENV OLFS_WAR_URL="https://www.opendap.org/pub/olfs/olfs-${OLFS_VERSION}-webapp.t
 
 ###############################################################
 # Retrieve, verify, and install Libdap
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, verifying, and installing libdap. rpm: $LIBDAP_RPM" \
-    && curl -s $LIBDAP_RPM > ./libdap.rpm \
-    && curl -s $LIBDAP_RPM.sig > ./libdap.rpm.sig \
+    && curl $ALLOW_EXPIRED -s $LIBDAP_RPM > ./libdap.rpm \
+    && curl $ALLOW_EXPIRED -s $LIBDAP_RPM.sig > ./libdap.rpm.sig \
     && gpg -v --verify ./libdap.rpm.sig ./libdap.rpm \
     && ls -l ./libdap* \
     && yum -y install ./libdap.rpm \
@@ -102,12 +120,13 @@ RUN set -e \
 # gpg --keyserver certserver.pgp.com --recv-keys 
 
 
-###############################################################
+################################################################
 # Retrieve, verify, and install the BES
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, verifying, and installing besd. rpm: $BES_RPM" \
-    && curl -s ${BES_RPM} > ./bes.rpm \
-    && curl -s ${BES_RPM}.sig > ./bes.rpm.sig \
+    && curl $ALLOW_EXPIRED -s ${BES_RPM} > ./bes.rpm \
+    && curl $ALLOW_EXPIRED -s ${BES_RPM}.sig > ./bes.rpm.sig \
     && gpg -v --verify ./bes.rpm.sig ./bes.rpm \
     && ls -l ./bes* \
     && yum -y install ./bes.rpm \
@@ -115,12 +134,13 @@ RUN set -e \
 
 RUN echo "besdaemon is here: "`which besdaemon`
 
-###############################################################
+################################################################
 # Retrieve, verify, and install the OLFS web application
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving And Installing OLFS-${OLFS_VERSION}" \
-    && curl -sfSL ${OLFS_WAR_URL} > olfs-${OLFS_VERSION}.tgz \
-    && curl -sfSL ${OLFS_WAR_URL}.sig > olfs-${OLFS_VERSION}.tgz.sig \
+    && curl $ALLOW_EXPIRED -sfSL ${OLFS_WAR_URL} > olfs-${OLFS_VERSION}.tgz \
+    && curl $ALLOW_EXPIRED -sfSL ${OLFS_WAR_URL}.sig > olfs-${OLFS_VERSION}.tgz.sig \
     && echo "Verifying tarball..." \
     && gpg --verify olfs-${OLFS_VERSION}.tgz.sig olfs-${OLFS_VERSION}.tgz \
     && echo "Unpacking tarball..." \
@@ -134,14 +154,16 @@ RUN set -e \
 RUN set -e \
     && mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
-    && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs 
+    && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs
 
-
+################################################################
 
 
 ###############################################################
 # retrieve and install the ncWMS web application
 #
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
 # This is ncWMS-2.2.2
 ENV NCWMS_WAR_URL=http://search.maven.org/remotecontent?filepath=uk/ac/rdg/resc/ncWMS/2.2.2/ncWMS-2.2.2.war
 
@@ -190,7 +212,35 @@ RUN set -e \
     && mv /tomcat7-server.xml ${CATALINA_HOME}/conf/server.xml \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/conf/server.xml
 
-###############################################################
+################################################################
+
+
+
+
+################################################################
+#
+# Retrieve, verify, and install the hyrax_regression_tests
+# project
+#
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+ENV TEST_INSTALL_DIR="/hyrax_regression_tests"
+RUN set -e \
+    && echo "Retrieving, and building hyrax regression tests." \
+    && echo "h_r_t will be in: ${TEST_INSTALL_DIR}" \
+    && mkdir -p ${TEST_INSTALL_DIR} \
+    && git clone -v https://github.com/opendap/hyrax_regression_tests ${TEST_INSTALL_DIR} \
+    && cd ${TEST_INSTALL_DIR} \
+    && autoreconf -vif \
+    && ./configure
+
+RUN set -e \
+    && cd ${TEST_INSTALL_DIR} \
+    && make check -k | tee /dev/null > mk.log 2>&1 \
+    && cat config.status \
+    && echo "h_r_t is here: " \
+    && ls -l ${TEST_INSTALL_DIR} \
+    && echo "SUCCESS: hyrax_regression_tests ready!"
+################################################################
 
 
 COPY entrypoint.sh /

--- a/hyrax-1.16.1/hyrax/Dockerfile
+++ b/hyrax-1.16.1/hyrax/Dockerfile
@@ -230,6 +230,7 @@ RUN set -e \
     && mkdir -p ${TEST_INSTALL_DIR} \
     && git clone -v https://github.com/opendap/hyrax_regression_tests ${TEST_INSTALL_DIR} \
     && cd ${TEST_INSTALL_DIR} \
+    && git checkout tags/hyrax-${HYRAX_VERSION_LABEL} \
     && autoreconf -vif \
     && ./configure
 
@@ -239,9 +240,6 @@ RUN set -e \
 RUN set -e \
     && cd ${TEST_INSTALL_DIR} \
     && make check -k | tee /dev/null > mk.log 2>&1 \
-    && cat config.status \
-    && echo "h_r_t is here: " \
-    && ls -l ${TEST_INSTALL_DIR} \
     && echo "SUCCESS: hyrax_regression_tests ready!"
 ################################################################
 

--- a/hyrax-snapshot/hyrax/Dockerfile
+++ b/hyrax-snapshot/hyrax/Dockerfile
@@ -68,35 +68,47 @@ RUN set -e && \
 # Update and install the needful.
 RUN set -e \
     && yum -y install \
-       tomcat \
-       unzip  \
-       which \
-       awscli \
-    && yum -y update \
+        tomcat \
+        unzip  \
+        which \
+        awscli \
+        autoconf \
+        automake \
+        git \
+   && yum -y update \
     && yum clean all 
 
 # Tomcat environment (Tomcat installed above by via yum)
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 ENV CATALINA_HOME /usr/share/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 RUN echo "CATALINA_HOME: $CATALINA_HOME"
 
+
+################################################################
 # SNAPSHOT URLs
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 ENV LIBDAP_RPM="s3://opendap.travis.build/libdap-snapshot.el7.x86_64.rpm"
 ENV BES_RPM="s3://opendap.travis.build/bes-snapshot.static.el7.x86_64.rpm"
 ENV OLFS_PACKAGE="s3://opendap.travis.build/olfs-snapshot-webapp.tgz"
-
 ###############################################################
+
+
+################################################################
 # Retrieve and install the latest libdap snapshot
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, and installing the latest libdap snapshot. rpm: $LIBDAP_RPM" \
     && aws --region=us-east-1 s3 cp ${LIBDAP_RPM}  ./libdap.rpm\
     && ls -l ./libdap* \
     && yum -y install ./libdap.rpm \
     && rm -f libdap.*
+################################################################
 
 
-###############################################################
+################################################################
 # Retrieve and install the latest BES snapshot
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, and installing the latest besd snapshot. rpm: $BES_RPM" \
     && aws --region=us-east-1 s3 cp ${BES_RPM}  ./bes.rpm\
@@ -105,9 +117,12 @@ RUN set -e \
     && rm -f bes.*
 
 RUN echo "besdaemon is here: "`which besdaemon`
+################################################################
 
-###############################################################
+
+################################################################
 # Retrieve, verify, and install the OLFS web application
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving and installing the latest olfs snapshot." \
     && aws --region=us-east-1 s3 cp ${OLFS_PACKAGE}  ./olfs-snapshot-webapp.tgz\
@@ -131,11 +146,13 @@ RUN echo "unset AWS_ACCESS_KEY_ID"     >> ~/.bash_profile
 RUN echo "unset AWS_SECRET_ACCESS_KEY" >> ~/.bash_profile
 RUN echo "unset AWS_ACCESS_KEY_ID"     >> ~/.bashrc
 RUN echo "unset AWS_SECRET_ACCESS_KEY" >> ~/.bashrc
+################################################################
 
 
-###############################################################
+################################################################
 # retrieve and install the ncWMS web application
-#
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
 # This is ncWMS-2.2.2
 ENV NCWMS_WAR_URL=http://search.maven.org/remotecontent?filepath=uk/ac/rdg/resc/ncWMS/2.2.2/ncWMS-2.2.2.war
 
@@ -184,7 +201,33 @@ RUN set -e \
     && mv /tomcat7-server.xml ${CATALINA_HOME}/conf/server.xml \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/conf/server.xml
 
-###############################################################
+################################################################
+
+
+################################################################
+#
+# Retrieve, verify, and install the hyrax_regression_tests
+# project
+#
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+ENV TEST_INSTALL_DIR="/hyrax_regression_tests"
+RUN set -e \
+    && echo "Retrieving, and building hyrax regression tests." \
+    && echo "h_r_t will be in: ${TEST_INSTALL_DIR}" \
+    && mkdir -p ${TEST_INSTALL_DIR} \
+    && git clone -v https://github.com/opendap/hyrax_regression_tests ${TEST_INSTALL_DIR} \
+    && cd ${TEST_INSTALL_DIR} \
+    && autoreconf -vif \
+    && ./configure
+
+# In order to get the executable "testsuite" to build we have to run
+# "make check" But that will fail at build time so the "make check" call
+# ends up pretty tortured to avoid a build error.
+RUN set -e \
+    && cd ${TEST_INSTALL_DIR} \
+    && make check -k | tee /dev/null > mk.log 2>&1 \
+    && echo "SUCCESS: hyrax_regression_tests ready!"
+################################################################
 
 
 COPY entrypoint.sh /

--- a/mkTest
+++ b/mkTest
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker exec -it hyrax  bash -c "cd hyrax_regression_tests; ./testsuite" 

--- a/template/hyrax/Dockerfile
+++ b/template/hyrax/Dockerfile
@@ -61,9 +61,12 @@ RUN set -e && \
 # Update and install the needful.
 RUN set -e \
     && yum -y install \
-       tomcat \
-       unzip  \
-       which \
+            tomcat \
+            unzip  \
+            which \
+            autoconf \
+            automake \
+            git \
     && yum -y update \
     && yum clean all 
 
@@ -72,7 +75,9 @@ ENV CATALINA_HOME /usr/share/tomcat
 ENV PATH $CATALINA_HOME/bin:$PATH
 RUN echo "CATALINA_HOME: $CATALINA_HOME"
 
-# Installs the OPeNDAP security public key.
+################################################################
+# Install the OPeNDAP security public key.
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 # TODO: We should get this from a well known key-server instead.
 RUN echo "Adding OPeNDAP Public Security Key"
 ENV OPENDAP_PUBLIC_KEY_FILE="security_at_opendap.org.pub.asc"
@@ -80,16 +85,21 @@ ENV OPENDAP_PUBLIC_KEY_URL="https://www.opendap.org/${OPENDAP_PUBLIC_KEY_FILE}"
 RUN set -e \
     && curl -s $OPENDAP_PUBLIC_KEY_URL > $OPENDAP_PUBLIC_KEY_FILE \
     && gpg --import $OPENDAP_PUBLIC_KEY_FILE
+###############################################################
 
 
+###############################################################
 # RELEASE URLs
-
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 ENV LIBDAP_RPM="https://www.opendap.org/pub/binary/hyrax-${HYRAX_VERSION}/centos-7.x/libdap-${LIBDAP_VERSION}.el7.x86_64.rpm"
 ENV BES_RPM="https://www.opendap.org/pub/binary/hyrax-${HYRAX_VERSION}/centos-7.x/bes-${BES_VERSION}.static.el7.x86_64.rpm"
 ENV OLFS_WAR_URL="https://www.opendap.org/pub/olfs/olfs-${OLFS_VERSION}-webapp.tgz"
+###############################################################
+
 
 ###############################################################
 # Retrieve, verify, and install Libdap
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, verifying, and installing libdap. rpm: $LIBDAP_RPM" \
     && curl -s $LIBDAP_RPM > ./libdap.rpm \
@@ -100,10 +110,12 @@ RUN set -e \
     && rm -f libdap.*
 
 # gpg --keyserver certserver.pgp.com --recv-keys 
+###############################################################
 
 
 ###############################################################
 # Retrieve, verify, and install the BES
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving, verifying, and installing besd. rpm: $BES_RPM" \
     && curl -s ${BES_RPM} > ./bes.rpm \
@@ -114,9 +126,12 @@ RUN set -e \
     && rm -f bes.*
 
 RUN echo "besdaemon is here: "`which besdaemon`
-
 ###############################################################
+
+
+################################################################
 # Retrieve, verify, and install the OLFS web application
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 RUN set -e \
     && echo "Retrieving And Installing OLFS-${OLFS_VERSION}" \
     && curl -sfSL ${OLFS_WAR_URL} > olfs-${OLFS_VERSION}.tgz \
@@ -135,13 +150,14 @@ RUN set -e \
     && mkdir -p ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs \
     && chmod 700 ${CATALINA_HOME}/webapps/opendap/WEB-INF/conf/logs 
-
-
+###############################################################
 
 
 ###############################################################
 # retrieve and install the ncWMS web application
 #
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
 # This is ncWMS-2.2.2
 ENV NCWMS_WAR_URL=http://search.maven.org/remotecontent?filepath=uk/ac/rdg/resc/ncWMS/2.2.2/ncWMS-2.2.2.war
 
@@ -191,6 +207,33 @@ RUN set -e \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/conf/server.xml
 
 ###############################################################
+
+
+################################################################
+#
+# Retrieve, verify, and install the hyrax_regression_tests
+# project
+#
+#  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+ENV TEST_INSTALL_DIR="/hyrax_regression_tests"
+RUN set -e \
+    && echo "Retrieving, and building hyrax regression tests." \
+    && echo "h_r_t will be in: ${TEST_INSTALL_DIR}" \
+    && mkdir -p ${TEST_INSTALL_DIR} \
+    && git clone -v https://github.com/opendap/hyrax_regression_tests ${TEST_INSTALL_DIR} \
+    && cd ${TEST_INSTALL_DIR} \
+    && git checkout tags/hyrax-${HYRAX_VERSION_LABEL} \
+    && autoreconf -vif \
+    && ./configure
+
+# In order to get the executable "testsuite" to build we have to run
+# "make check" But that will fail at build time so the "make check" call
+# ends up pretty tortured to avoid a build error.
+RUN set -e \
+    && cd ${TEST_INSTALL_DIR} \
+    && make check -k | tee /dev/null > mk.log 2>&1 \
+    && echo "SUCCESS: hyrax_regression_tests ready!"
+################################################################
 
 
 COPY entrypoint.sh /


### PR DESCRIPTION
By separating the Hyrax regression tests from the OLFS project we make it possible to use them independently of the OLFS frame work against any running Hyrax with distribution data.

In the PR we add code to the hyrax-1.16.1 Dockerfile to clone the hyrax_regression_tests project into the Docker image, checkout the associated release tag of the HRT, and the autoreconf/configure/make the repo so that it can be used to validate the running server.

TODO:
- Assuming this is a satisfactory result, then this code needs to be added to the `template/hyrax/Dockerfile` and to the `hyrax-snapshot/hyrax/Dockerfile`