### PR TITLE
beslog2json.awk rewrite

### DIFF
--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -38,7 +38,7 @@ BEGIN {
 
         # Transmit info log messages..
         send_info = process_bool_value(send_info, "false");
-        
+
         # Transmit verbose  log messages.
         send_verbose = process_bool_value(send_verbose, "false");
     }
@@ -65,7 +65,7 @@ BEGIN {
     # Look for a leading [ which indicates an incorrectly constructed log entry
     if($0 ~ /^\[/){
         # This is a logging error.
-        if ( send_error=="true") {
+        if ( send_error=="true" ) {
             # Make an special error log entry about the error in the log.
             printf ("{ %s%s\"%stime\": -1", n, indent, prefix);
             printf (", %s%s\"%spid\": -1", n, indent, prefix);
@@ -89,64 +89,65 @@ BEGIN {
             #printf(", %s%s\"%sOLFS\": \"%s\"", n, indent, prefix, $4);
 
             # ip-address of requesting client's system.
-            printf(", %s%s\"%sclient_ip\": \"%s\"", n, indent, prefix, $5);
+            write_kvp_str("client_ip",$5);
 
             # The value of the User-Agent request header sent from the client.
-            printf(", %s%s\"%suser_agent\": \"%s\"", n, indent, prefix, $6);
+            write_kvp_str("user_agent",$6);
 
             # The session id, if present.
-            printf(", %s%s\"%ssession_id\": \"%s\"", n, indent, prefix, $7);
+            write_kvp_str("session_id",$7);
 
             # The user's user id, if a user is logged in.
-            printf(", %s%s\"%suser_id\": \"%s\"", n, indent, prefix, $8);
+            write_kvp_str("user_id",$8);
 
             # The time the the request was received.
-            printf(", %s%s\"%sstart_time\": %s", n, indent, prefix, $9);
+            write_kvp_num("start_time",$9);
 
             # We are not so sure what this number is...
-            printf(", %s%s\"%sduration\": %s", n, indent, prefix, $10);
+            write_kvp_num("duration",$10);
 
             # The HTTP verb of the request (GET, POST, etc)
-            printf(", %s%s\"%shttp_verb\": \"%s\"", n, indent, prefix, $11);
+            write_kvp_str("http_verb",$11);
 
             # The path component of the requested resource.
-            printf(", %s%s\"%surl_path\": \"%s\"", n, indent, prefix, $12);
+            write_kvp_str("url_path",$12);
 
             # The query string, if any, submitted with the request.
-            printf(", %s%s\"%squery_string\": \"%s\"", n, indent, prefix, $13);
+            write_kvp_str("query_string",$13);
 
             # Field 14 is a field that indicates the following fields orginated
             # in the BES, it is not semantically important to NGAP
-            # printf(", %s%s\"%sbes\": \"%s\"", n, indent, prefix, $14);
+            # write_kvp_str("bes",$14);
 
             # The type of BES action/request/command invoked by the request
-            printf(", %s%s\"%sbes_request\": \"%s\"", n, indent, prefix, $15);
+            write_kvp_str("bes_request",$15);
 
             # The DAP protocl
-            printf(", %s%s\"%sdap_version\": \"%s\"", n, indent, prefix, $16);
+            write_kvp_str("dap_version",$16);
 
             # The local file path to the resource.
-            printf(", %s%s\"%slocal_path\": \"%s\"", n, indent, prefix, $17);
+            write_kvp_str("local_path",$17);
 
             # Field 18 is a duplicate of field 13 and if the query string is absent
             # then field 18 will be missing entirely.
             printf(", %s%s\"%sconstraint_expression\": \"%s\"", n, indent, prefix, $18);
+            write_kvp_str("constraint_expression",$18);
 
             print_closer();
         }
         else if(type=="info" && send_info=="true"){
             print_opener();
-            printf(", %s%s\"%smessage\": \"%s\"",  n, indent,  prefix, $4);
+            write_kvp_str("message",$4);
             print_closer();
         }
         else if(type=="error" && send_error=="true"){
             print_opener();
-            printf(", %s%s\"%smessage\": \"%s\"",  n, indent,  prefix, $4);
+            write_kvp_str("message",$4);
             print_closer();
         }
         else if(type=="verbose" && send_verbose=="true"){
             print_opener();
-            printf(", %s%s\"%smessage\": \"%s\"",  n, indent,  prefix, $4);
+            write_kvp_str("message",$4);
             print_closer();
         }
         else if(type == "timing" && send_timing=="true"){
@@ -157,9 +158,9 @@ BEGIN {
                 # 1601642669|&|2122|&|timing|&|start_us|&|1601642669945133|&|-|&|TIMER_NAME
                 #      1         2      3        4             5             6      7
                 print_opener();
-                printf(", %s%s\"%sstart_time_us\": %s", n, indent, prefix, $5);
-                printf(", %s%s\"%sreq_id\": \"%s\"", n, indent, prefix, $6);
-                printf(", %s%s\"%sname\": \"%s\"", n, indent, prefix, $7);
+                write_kvp_num("start_time",$5);
+                write_kvp_str("req_id",$6);
+                write_kvp_str("name",$7);
                 print_closer();
             }
             else if(time_type=="elapsed_us"){
@@ -168,15 +169,16 @@ BEGIN {
                 # |&|1601653546271786|&|ReqId|&|TIMER_NAME
                 #          9              10       11
                 print_opener();
-                printf(", %s%s\"%selapsed_time_us\": %s", n, indent, prefix, $5);
-                printf(", %s%s\"%sstart_time_us\": %s", n, indent, prefix, $7);
-                printf(", %s%s\"%sstop_time_us\": %s", n, indent, prefix, $9);
-                printf(", %s%s\"%sreq_id\": \"%s\"", n, indent, prefix, $10);
-                printf(", %s%s\"%sname\": \"%s\"", n, indent, prefix, $11);
+                write_kvp_num("elapsed_time_us",$5);
+                write_kvp_num("start_time_us",$7);
+                write_kvp_num("stop_time_us",$9);
+                write_kvp_str("req_id",$10);
+                write_kvp_str("name",$11);
                 print_closer();
             }
             else {
-                printf(", %s%s\"%sLOG_ERROR\": \"FAILED to process: %s\"", n , indent, prefix, $0);
+                msg = "FAILED to process '"$0"'";
+                write_kvp_str("LOG_ERROR",msg);
             }
         }
     }
@@ -205,4 +207,11 @@ function process_bool_value(var_val, dfault, ret_val){
         }
     }
     return ret_val;
+}
+
+function write_kvp_num(key,value){
+    printf (", %s%s\"%s%s\": %s", n, indent, prefix, key, value);
+}
+function write_kvp_str(key,value){
+    printf (", %s%s\"%s%s\": \"%s\"", n, indent, prefix, key, value);
 }

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -19,37 +19,44 @@
 BEGIN {
     FS="\\|&\\|";
 
+    # A namespace prefix for our variable names, if desired.
     prefix="hyrax_";
 
-    if(send_timing!="true"){
-        send_timing="false";
+    if(send_all=="true"){
+        # Send everything as json.
+        send_error="true";
+        send_timing="true";
+        send_info="true";
+        send_verbose="true";
+    }
+    else{
+        # Transmit error log messages.
+        send_error = process_bool_value(send_error, "true");
+
+        # Transmit timing data.
+        send_timing = process_bool_value(send_timing, "false");
+
+        # Transmit info log messages..
+        send_info = process_bool_value(send_info, "false");
+        
+        # Transmit verbose  log messages.
+        send_verbose = process_bool_value(send_verbose, "false");
     }
 
-    if(send_info!="true"){
-        send_info="false";
-    }
-
-    if(send_error!="true"){
-        send_error="false";
-    }
-
-    if(send_verbose!="true"){
-        send_verbose="false";
-    }
-
-
+    # Debuggin Mode
     if(debug!="true"){
          debug="false";
     }
 
-    if(pretty!="true"){
-        pretty="false";
-    }
-
+    # Pretty JSON mode
     if(pretty=="true"){
         n="\n";
         indent="    ";
     }
+    else{
+        pretty="false";
+    }
+
 }
 {
     # First, escape all of the double quotes in the input line, because json.
@@ -157,7 +164,7 @@ BEGIN {
             }
             else if(time_type=="elapsed_us"){
                 # 1601653546|&|7096|&|timing|&|elapsed_us|&|2169|&|start_us|&|1601653546269617|&|stop_us
-                #     1          2      3         4          5        6            7                8
+                #     1          2      3          4          5        6            7                8
                 # |&|1601653546271786|&|ReqId|&|TIMER_NAME
                 #          9              10       11
                 print_opener();
@@ -188,4 +195,14 @@ function print_opener(){
 
 function print_closer(){
     printf("%s}\n", n);
+}
+
+function process_bool_value(var_val, dfault, ret_val){
+    ret_val = dfault;
+    if (length(var_val)>0) {
+        if(var_val != "true" && var_val != "1"){
+            ret_val="false";
+        }
+    }
+    return ret_val;
 }

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -16,6 +16,61 @@
 # 1601642679|&|2122|&|request|&|RequestFields
 #
 # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
+
+########################################################################
+#
+# Opens a json log element with kvp for time, pid and log entry type.
+#
+function print_opener(){
+    printf("{ %s", n);
+    printf("%s\"%stime\": %s", indent, prefix, $1);
+    write_kvp_num("pid", $2);
+    write_kvp_str("type", $3);
+}
+
+########################################################################
+#
+# Closes a json element.
+#
+function print_closer(){
+    printf("%s}\n", n);
+}
+
+########################################################################
+#
+# Retuns the boolean state based on the passed value and the default.
+#
+function process_bool_value(var_val, dfault, ret_val){
+    ret_val = dfault;
+    if (length(var_val)>0) {
+        if(var_val != "true" && var_val != "1"){
+            ret_val="false";
+        }
+    }
+    return ret_val;
+}
+
+########################################################################
+#
+# Writes a key value pair in json. The value is handled as a number
+#
+function write_kvp_num(key,value){
+    printf (", %s%s\"%s%s\": %s", n, indent, prefix, key, value);
+}
+
+########################################################################
+#
+# Writes a key value pair in json. The value handled as a string.
+#
+function write_kvp_str(key,value){
+    printf (", %s%s\"%s%s\": \"%s\"", n, indent, prefix, key, value);
+}
+
+########################################################################
+#
+# BEGIN is executed one time, at the beginning of the show.
+#
 BEGIN {
     # Set the field seperator to the BES log's "|&|" business.
     FS="\\|&\\|";
@@ -59,6 +114,11 @@ BEGIN {
     }
 
 }
+#########################################################################
+#
+# This is essentially the main() of an awk program.
+# This {...} block is run on each line in the input file.
+#
 {
     # First, escape all of the double quotes in the input line, because json.
     gsub(/\"/, "\\\"");
@@ -135,7 +195,6 @@ BEGIN {
 
             # Field 18 is a duplicate of field 13 and if the query string is absent
             # then field 18 will be missing entirely.
-            printf(", %s%s\"%sconstraint_expression\": \"%s\"", n, indent, prefix, $18);
             write_kvp_str("constraint_expression",$18);
 
             print_closer();
@@ -194,51 +253,3 @@ BEGIN {
     }
 }
 
-########################################################################
-#
-# Opens a json log element with kvp for time, pib and log entry type.
-#
-function print_opener(){
-    printf("{ %s", n);
-    printf("%s\"%stime\": %s", indent, prefix, $1);
-    write_kvp_num("pid",$2);
-    write_kvp_str("type", $3);
-}
-
-########################################################################
-#
-# Closes a json element.
-#
-function print_closer(){
-    printf("%s}\n", n);
-}
-
-########################################################################
-#
-# Retuns the boolean state based on the passed value and the default.
-#
-function process_bool_value(var_val, dfault, ret_val){
-    ret_val = dfault;
-    if (length(var_val)>0) {
-        if(var_val != "true" && var_val != "1"){
-            ret_val="false";
-        }
-    }
-    return ret_val;
-}
-
-########################################################################
-#
-# Writes a key value pair in json. The value is handled as a number
-#
-function write_kvp_num(key,value){
-    printf (", %s%s\"%s%s\": %s", n, indent, prefix, key, value);
-}
-
-########################################################################
-#
-# Writes a key value pair in json. The value handled as a string.
-#
-function write_kvp_str(key,value){
-    printf (", %s%s\"%s%s\": \"%s\"", n, indent, prefix, key, value);
-}

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -17,6 +17,26 @@
 #
 # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
+########################################################################
+#
+# Retuns the boolean state based on the passed value and the default.
+#
+# Awk doesn't have boolean types so for this work I have it use the
+# string values of "true" and "false". If setting the value from the
+# command line like:
+#    awk -v foo=true -v bar=1
+# This function will accept "true" or 1 (and only 1) as a true value.
+#
+function process_bool_value(var_val, dfault, ret_val){
+    ret_val = dfault;
+    if (length(var_val)>0) {
+        if(var_val != "true" && var_val != "1"){
+            ret_val="false";
+        }
+    }
+    return ret_val;
+}
+
 
 ########################################################################
 #
@@ -35,20 +55,6 @@ function print_opener(){
 #
 function print_closer(){
     printf("%s}\n", n);
-}
-
-########################################################################
-#
-# Retuns the boolean state based on the passed value and the default.
-#
-function process_bool_value(var_val, dfault, ret_val){
-    ret_val = dfault;
-    if (length(var_val)>0) {
-        if(var_val != "true" && var_val != "1"){
-            ret_val="false";
-        }
-    }
-    return ret_val;
 }
 
 ########################################################################
@@ -114,9 +120,10 @@ BEGIN {
     }
 
 }
+
 #########################################################################
 #
-# This is essentially the main() of an awk program.
+# This is essentially the main() of any awk program.
 # This {...} block is run on each line in the input file.
 #
 {

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -99,7 +99,7 @@ BEGIN {
     }
     else{
         # Transmit request log entries.
-        send_requests=process_bool_value(send_error, "true");
+        send_requests=process_bool_value(send_requests, "true");
 
         # Transmit error log messages.
         send_error = process_bool_value(send_error, "true");

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -63,11 +63,11 @@ BEGIN {
     # First, escape all of the double quotes in the input line, because json.
     gsub(/\"/, "\\\"");
 
-    # Look for a leading [ which indicates an incorrectly constructed log entry
+    # Look for a leading "[" which indicates an incorrectly formatted log entry
     if($0 ~ /^\[/){
         # This is a logging error.
         if ( send_error=="true" ) {
-            # Make an special error log entry about the error in the log.
+            # Make an special error log entry about the error in the log format.
             printf ("{ %s%s\"%stime\": -1", n, indent, prefix);
             printf (", %s%s\"%spid\": -1", n, indent, prefix);
             printf (", %s%s\"%stype\": \"error\"", n, indent, prefix);

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -1,6 +1,21 @@
 #
 # Translates OPeNDAP bes.logs into JSON
 #
+# Log Fields type==request
+# 1601646465|&|2122|&|request|&|OLFS|&|0:0:0:0:0:0:0:1|&|USER_AGENT|&|92F3C71F959B56515C98A09088CA2A8E
+#    1          2        3       4           5              6               7
+# |&|-|&|1601646465304|&|18|&|HTTP-GET|&|/opendap/hyrax/data/nc/fnoc1.nc.dds|&|u|&|BES
+#    8     9             10     11              12                             13   14
+# |&|get.dds|&|dap2|&|/Users/ndp/OPeNDAP/hyrax/build/share/hyrax/data/nc/fnoc1.nc|&|u
+#      15       16                              17                                  18
+#
+# 1601642669|&|2122|&|timing|&|TimingFields
+# 1601642669|&|2122|&|verbose|&|MessageField
+# 1601642679|&|2122|&|info|&|MessageField
+# 1601642679|&|2122|&|error|&|MessageField
+# 1601642679|&|2122|&|request|&|RequestFields
+#
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 BEGIN {
     FS="\\|&\\|";
 
@@ -16,36 +31,22 @@ BEGIN {
         n="\n";
         indent="    ";
     }
-
-
-# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-# Log Fields type==request
-# 1601646465|&|2122|&|request|&|OLFS|&|0:0:0:0:0:0:0:1|&|USER_AGENT|&|92F3C71F959B56515C98A09088CA2A8E
-#    1          2        3       4           5              6               7
-# |&|-|&|1601646465304|&|18|&|HTTP-GET|&|/opendap/hyrax/data/nc/fnoc1.nc.dds|&|u|&|BES
-#    8     9             10     11              12                             13   14
-# |&|get.dds|&|dap2|&|/Users/ndp/OPeNDAP/hyrax/build/share/hyrax/data/nc/fnoc1.nc|&|u
-#      15       16                              17                                  18
-
-# 1601642669|&|2122|&|timing|&|TimingFields
-# 1601642669|&|2122|&|verbose|&|MessageField
-# 1601642679|&|2122|&|info|&|MessageField
-# 1601642679|&|2122|&|error|&|MessageField
-# 1601642679|&|2122|&|request|&|RequestFields
-
 }
 {
+    # First, escape all of the double quotes in the input line, because json.
+    gsub(/\"/, "\\\"");
+
     # Look for a leading [ which indicates an incorrectly constructed log entry
     if($0 ~ /^\[/){
+        # This is a logging error.
+        # Make an error log entry about the error in the log.
         printf("{ %s%s\"time\": -1", n, indent, now);
         printf(", %s%s\"pid\": -1", n, indent);
         printf(", %s%s\"type\": \"error\"", n, indent);
-        msg = "OUCH! Input line "NR" appears to use [ and ] to delimit values. SKIPPING!";
+        msg = "OUCH! Input log line "NR" appears to use [ and ] to delimit values. Line: "$0;
         printf(", %s%s\"message\": \"%s\"} %s", n, indent, msg, n);
     }
     else if($0.length() != 0) { # Don't process an empty line...
-        # First, escape all of the double quotes in the values of the log fields.
-        gsub(/\"/, "\\\"");
 
         if(debug=="true"){
             print "------------------------------------------------";
@@ -58,7 +59,8 @@ BEGIN {
         printf(", %s%s\"type\": \"%s\"",  n, indent, type, n);
 
         if(type=="request"){
-            # OLFS
+            # Field $4 aleays has the value OLFS. It marks the beginning
+            # of things sent by the OLFS. The tag not needed for ngap logs.
             #printf(", %s%s\"OLFS\": \"%s\"", n, indent,$4);
 
             # ip-address of requesting client's system.
@@ -116,34 +118,31 @@ BEGIN {
             if(time_type=="start_us"){
                 # 1601642669|&|2122|&|timing|&|start_us|&|1601642669945133|&|-|&|TIMER_NAME
                 #      1         2      3        4             5             6      7
-                printf(", %s%s\"%s\": %s", n, indent, "start_time_us", $5);
-                printf(", %s%s\"%s\": \"%s\"", n, indent, "req_id", $6);
-                printf(", %s%s\"%s\": \"%s\"", n, indent, "name:", $7);
+                printf(", %s%s\"start_time_us\": %s", n, indent, $5);
+                printf(", %s%s\"req_id\": \"%s\"", n, indent, $6);
+                printf(", %s%s\"name\": \"%s\"", n, indent, $7);
             }
             else if(time_type=="elapsed_us"){
-                #1601653546|&|7096|&|timing|&|elapsed_us|&|2169|&|start_us|&|1601653546269617|&|stop_us|&|1601653546271786|&|ReqId|&|TIMER_NAME
-                #     1          2      3         4          5        6            7                8           9              10       11
-                printf(", %s%s\"%s\": %s", n, indent, "elapsed_time_us", $5);
-                printf(", %s%s\"%s\": %s", n, indent, "start_time_us", $7);
-                printf(", %s%s\"%s\": %s", n, indent, "stop_time_us", $9);
-                printf(", %s%s\"%s\": \"%s\"", n, indent, "req_id", $10);
-                printf(", %s%s\"%s\": \"%s\"", n, indent,  "name:", $11);
+                # 1601653546|&|7096|&|timing|&|elapsed_us|&|2169|&|start_us|&|1601653546269617|&|stop_us
+                #     1          2      3         4          5        6            7                8
+                # |&|1601653546271786|&|ReqId|&|TIMER_NAME
+                #          9              10       11
+                printf(", %s%s\"elapsed_time_us\": %s", n, indent, $5);
+                printf(", %s%s\"start_time_us\": %s", n, indent, $7);
+                printf(", %s%s\"stop_time_us\": %s", n, indent, $9);
+                printf(", %s%s\"req_id\": \"%s\"", n, indent, $10);
+                printf(", %s%s\"name\": \"%s\"", n, indent, $11);
 
             }
             else {
                 printf(", %s%s\"LOG_ERROR\": \"FAILED to process: %s\"", n , indent, $0);
             }
-
         }
-        else {
-            if(debug == "true"){
-                print "Line "NR" is blank, ignored."
-            }
-        }
-
-
         printf("%s}\n", n);
     }
-
-
+    else {
+        if(debug == "true"){
+            print "# Line "NR" is blank, ignored."
+        }
+    }
 }

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -88,9 +88,9 @@ BEGIN {
         if(type=="request"){
             print_opener();
 
-            # Field $4 aleays has the value OLFS. It marks the beginning
-            # of things sent by the OLFS. The tag not needed for ngap logs.
-            #printf(", %s%s\"%sOLFS\": \"%s\"", n, indent, prefix, $4);
+            # Field $4 always has the value "OLFS". It marks the beginning
+            # of things sent by the OLFS. The tag is not needed for ngap logs.
+            # write_kvp_str("OLFS",$4);
 
             # ip-address of requesting client's system.
             write_kvp_str("client_ip",$5);
@@ -119,8 +119,9 @@ BEGIN {
             # The query string, if any, submitted with the request.
             write_kvp_str("query_string",$13);
 
-            # Field 14 is a field that indicates the following fields orginated
-            # in the BES, it is not semantically important to NGAP
+            # Field $14 always has the value "bes" and is used to indicate
+            # that the following fields orginated in the BES. It is not 
+            # semantically important to NGAP
             # write_kvp_str("bes",$14);
 
             # The type of BES action/request/command invoked by the request

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -17,6 +17,7 @@
 #
 # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 BEGIN {
+    # Set the field seperator to the BES log's "|&|" business.
     FS="\\|&\\|";
 
     # A namespace prefix for our variable names, if desired.

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -15,6 +15,11 @@
 # 1601642679|&|2122|&|error|&|MessageField
 # 1601642679|&|2122|&|request|&|RequestFields
 #
+#
+# You can set the control variables from the awk command line like:
+#
+#     tail -f /var/log/bes/bes.log | awk -f beslog2json.awk -v send_info=true -v send_timing=true -v prefix=""
+#
 # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 ########################################################################
@@ -86,12 +91,16 @@ BEGIN {
 
     if(send_all=="true"){
         # Send everything as json.
+        send_requests="true"
         send_error="true";
         send_timing="true";
         send_info="true";
         send_verbose="true";
     }
     else{
+        # Transmit request log entries.
+        send_requests=process_bool_value(send_error, "true");
+
         # Transmit error log messages.
         send_error = process_bool_value(send_error, "true");
 
@@ -152,7 +161,7 @@ BEGIN {
             print $0;
         }
         type=$3;
-        if(type=="request"){
+        if(type=="request" && send_requests=="true"){
             print_opener();
 
             # Field $4 always has the value "OLFS". It marks the beginning

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -17,210 +17,133 @@ BEGIN {
         indent="    ";
     }
 
+
+# -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+# Log Fields type==request
+# 1601646465|&|2122|&|request|&|OLFS|&|0:0:0:0:0:0:0:1|&|USER_AGENT|&|92F3C71F959B56515C98A09088CA2A8E
+#    1          2        3       4           5              6               7
+# |&|-|&|1601646465304|&|18|&|HTTP-GET|&|/opendap/hyrax/data/nc/fnoc1.nc.dds|&|u|&|BES
+#    8     9             10     11              12                             13   14
+# |&|get.dds|&|dap2|&|/Users/ndp/OPeNDAP/hyrax/build/share/hyrax/data/nc/fnoc1.nc|&|u
+#      15       16                              17                                  18
+
 # 1601642669|&|2122|&|timing|&|TimingFields
 # 1601642669|&|2122|&|verbose|&|MessageField
 # 1601642679|&|2122|&|info|&|MessageField
 # 1601642679|&|2122|&|error|&|MessageField
 # 1601642679|&|2122|&|request|&|RequestFields
 
-
-
-    # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-    # Log line base.
-
-    # The time that the log message was written.
-    log_line_base[1]="time";
-
-    # The PID of the beslistener that wrote the log entry.
-    log_line_base[2]="pid";
-
-    # The message associate with the log entry
-    log_line_base[3]="log_name";
-
-
-
-    # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-    # Request Log Fields
-
-# 1601646255|&|2122|&|request|&|OLFS|&|0:0:0:0:0:0:0:1|&|USER_AGENT|&|92F3C71F959B56515C98A09088CA2A8E|&|-|&|1601646255543|&|10|&|HTTP-GET|&|/opendap/hyrax/data/nc/nc4_strings.nc.dds|&|-|&|BES|&|get.dds|&|dap2|&|/Users/ndp/OPeNDAP/hyrax/build/share/hyrax/data/nc/nc4_strings.nc
-# 1601646465|&|2122|&|request|&|OLFS|&|0:0:0:0:0:0:0:1|&|USER_AGENT|&|92F3C71F959B56515C98A09088CA2A8E|&|-|&|1601646465304|&|18|&|HTTP-GET|&|/opendap/hyrax/data/nc/fnoc1.nc.dds|&|u|&|BES|&|get.dds|&|dap2|&|/Users/ndp/OPeNDAP/hyrax/build/share/hyrax/data/nc/fnoc1.nc|&|u
-
-    # OLFS Tag.
-    request_log_fields[4]="OLFS";
-
-    # ip-address of requesting client's system.
-    request_log_fields[5]="client_ip";
-
-    # The value of the User-Agent request header sent from the client.
-    request_log_fields[6]="user_agent";
-
-    # The session id, if present.
-    request_log_fields[7]="session_id";
-
-    # The user's user id, if a user is logged in.
-    request_log_fields[8]="user_id";
-
-    # The time the the request was received.
-    request_log_fields[9]="start_time";
-
-    # We are not so sure what this number is...
-    request_log_fields[10]="duration";
-
-    # The HTTP verb of the request (GET, POST, etc)
-    request_log_fields[11]="http_verb";
-
-    # The path component of the requested resource.
-    request_log_fields[12]="url_path";
-
-    # The query string, if any, submitted with the request.
-    request_log_fields[13]="query_string";
-
-    # Field 13 is a field that indicates the following fields orginated
-    # in the BES, it is not semantically important to NGAP
-    request_log_fields[14]="bes";
-
-    # The type of BES action/request/command invoked by the request
-    request_log_fields[15]="bes_request";
-
-    # The DAP protocl
-    request_log_fields[16]="dap_version";
-
-    # The local file path to the resource.
-    request_log_fields[17]="local_path";
-
-    # Field 18 is a duplicate of field 13 and if the query string is absent
-    # then field 18 will be missing entirely.
-    request_log_fields[18]="constraint_expression";
-
-    # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-    # Error/Verbose/Info Fields
-
-    # The message associate with the log entry
-    msg_fields[4]="message";
-
-
-    # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-    # Start Timing Fields
-    # 1601642669|&|2122|&|timing|&|start_us|&|1601642669943035|&|ReqId|&|TIMER_NAME
-
-    # The message associate with the log entry
-    start_time_fields[4]="start_us";
-
-    # The message associate with the log entry
-    start_time_fields[5]="start_time_us";
-
-    # The message associate with the log entry
-    start_time_fields[6]="ReqId";
-
-    # The message associate with the log entry
-    start_time_fields[7]="Name";
-
-    # -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
-    # Stop Timing Fields
-    # 1601642669|&|2122|&|timing|&|stop_us|&|1601642669944587|&|elapsed_us|&|1552|&ReqId|&|TIMER_NAME
-    #     1          2      3         4            5               6           7     8        9
-    # The message associate with the log entry
-    stop_time_fields[4]="stop_us";
-
-    # The message associate with the log entry
-    stop_time_fields[5]="stop_time_us";
-
-    # The message associate with the log entry
-    stop_time_fields[6]="elapsed_us";
-
-    # The message associate with the log entry
-    stop_time_fields[6]="elapsed_time_us";
-
-    # The message associate with the log entry
-    stop_time_fields[7]="ReqId";
-
-    # The message associate with the log entry
-    stop_time_fields[4]="Name";
-
-
 }
 {
-    # First, escape all of the double quotes in the values of the log fields.
-    gsub(/\"/, "\\\"");
-
-    if(debug=="true"){
-        print "------------------------------------------------";
-        print $0;
+    # Look for a leading [ which indicates an incorrectly constructed log entry
+    if($0 ~ /^\[/){
+        printf("{ %s%s\"time\": -1", n, indent, now);
+        printf(", %s%s\"pid\": -1", n, indent);
+        printf(", %s%s\"type\": \"error\"", n, indent);
+        msg = "OUCH! Input line "NR" appears to use [ and ] to delimit values. SKIPPING!";
+        printf(", %s%s\"message\": \"%s\"} %s", n, indent, msg, n);
     }
+    else if($0.length() != 0) { # Don't process an empty line...
+        # First, escape all of the double quotes in the values of the log fields.
+        gsub(/\"/, "\\\"");
 
-    ltime=$1;
-    pid=$2;
-    log_name=$3;
-    printf("{%s", n);
-    printf("%s\"time\": %s, %s", indent, ltime, n);
-    printf("%s\"pid\": \"%s\", %s", indent, pid, n);
-    printf("%s\"type\": \"%s\"", indent, log_name);
-
-    if(log_name=="request"){
-        for(i=4; i<=NF  ; i++){
-            if(i!=4 && i!=14 && i!=18){
-                printf(", %s",n);
-                if(i==9 || i==10){
-                    printf("%s\"%s\": %s",indent,request_log_fields[i],$i);
-                }
-                else {
-                    printf("%s\"%s\": \"%s\"",indent,request_log_fields[i],$i);
-                }
-             }
+        if(debug=="true"){
+            print "------------------------------------------------";
+            print $0;
         }
-    }
-    else if(log_name=="info" || log_name=="error" || log_name=="verbose" ){
-        printf(", %s",n);
-        printf("%s\"%s\": \"%s\"", indent, msg_fields[4], $4);
-    }
-    else if(log_name == "timing"){
+        printf("{ %s", n);
+        printf("%s\"time\": %s", indent, $1);
+        printf(", %s%s\"pid\": %s",  n, indent, $2, n);
+        type=$3;
+        printf(", %s%s\"type\": \"%s\"",  n, indent, type, n);
 
-        time_type = $4;
+        if(type=="request"){
+            # OLFS
+            #printf(", %s%s\"OLFS\": \"%s\"", n, indent,$4);
 
-        if(time_type=="start_us"){
-            # 1601642669|&|2122|&|timing|&|start_us|&|1601642669945133|&|-|&|TIMER_NAME
-            #      1         2      3        4             5             6      7
-            printf(", %s%s\"%s\": %s", n, indent, "start_time_us", $5);
-            printf(", %s%s\"%s\": \"%s\"", n, indent, "req_id", $6);
-            printf(", %s%s\"%s\": \"%s\"", n, indent, "name:", $7);
+            # ip-address of requesting client's system.
+            printf(", %s%s\"client_ip\": \"%s\"", n, indent,$5);
+
+            # The value of the User-Agent request header sent from the client.
+            printf(", %s%s\"user_agent\": \"%s\"", n, indent,$6);
+
+            # The session id, if present.
+            printf(", %s%s\"session_id\": \"%s\"", n, indent,$7);
+
+            # The user's user id, if a user is logged in.
+            printf(", %s%s\"user_id\": \"%s\"", n, indent,$8);
+
+            # The time the the request was received.
+            printf(", %s%s\"start_time\": %s", n, indent,$9);
+
+            # We are not so sure what this number is...
+            printf(", %s%s\"duration\": %s", n, indent,$10);
+
+            # The HTTP verb of the request (GET, POST, etc)
+            printf(", %s%s\"http_verb\": \"%s\"", n, indent,$11);
+
+            # The path component of the requested resource.
+            printf(", %s%s\"url_path\": \"%s\"", n, indent,$12);
+
+            # The query string, if any, submitted with the request.
+            printf(", %s%s\"query_string\": \"%s\"", n, indent,$13);
+
+            # Field 14 is a field that indicates the following fields orginated
+            # in the BES, it is not semantically important to NGAP
+            # printf(", %s%s\"bes\": \"%s\"", n, indent,$14);
+
+            # The type of BES action/request/command invoked by the request
+            printf(", %s%s\"bes_request\": \"%s\"", n, indent,$15);
+
+            # The DAP protocl
+            printf(", %s%s\"dap_version\": \"%s\"", n, indent,$16);
+
+            # The local file path to the resource.
+            printf(", %s%s\"local_path\": \"%s\"", n, indent,$17);
+
+            # Field 18 is a duplicate of field 13 and if the query string is absent
+            # then field 18 will be missing entirely.
+            printf(", %s%s\"constraint_expression\": \"%s\"", n, indent, $18);
+
         }
-        else if(time_type=="elapsed_us"){
-            #1601653546|&|7096|&|timing|&|elapsed_us|&|2169|&|start_us|&|1601653546269617|&|stop_us|&|1601653546271786|&|ReqId|&|TIMER_NAME
-            #     1          2      3         4          5        6            7                8           9              10       11
-            printf(", %s%s\"%s\": %s", n, indent, "elapsed_time_us", $5);
-            printf(", %s%s\"%s\": %s", n, indent, "start_time_us", $7);
-            printf(", %s%s\"%s\": %s", n, indent, "stop_time_us", $9);
-            printf(", %s%s\"%s\": \"%s\"", n, indent, "req_id", $10);
-            printf(", %s%s\"%s\": \"%s\"", n, indent,  "name:", $11);
+        else if(type=="info" || type=="error" || type=="verbose" ){
+            printf(", %s%s\"message\": \"%s\"",  n, indent, $4);
+        }
+        else if(type == "timing"){
+
+            time_type = $4;
+
+            if(time_type=="start_us"){
+                # 1601642669|&|2122|&|timing|&|start_us|&|1601642669945133|&|-|&|TIMER_NAME
+                #      1         2      3        4             5             6      7
+                printf(", %s%s\"%s\": %s", n, indent, "start_time_us", $5);
+                printf(", %s%s\"%s\": \"%s\"", n, indent, "req_id", $6);
+                printf(", %s%s\"%s\": \"%s\"", n, indent, "name:", $7);
+            }
+            else if(time_type=="elapsed_us"){
+                #1601653546|&|7096|&|timing|&|elapsed_us|&|2169|&|start_us|&|1601653546269617|&|stop_us|&|1601653546271786|&|ReqId|&|TIMER_NAME
+                #     1          2      3         4          5        6            7                8           9              10       11
+                printf(", %s%s\"%s\": %s", n, indent, "elapsed_time_us", $5);
+                printf(", %s%s\"%s\": %s", n, indent, "start_time_us", $7);
+                printf(", %s%s\"%s\": %s", n, indent, "stop_time_us", $9);
+                printf(", %s%s\"%s\": \"%s\"", n, indent, "req_id", $10);
+                printf(", %s%s\"%s\": \"%s\"", n, indent,  "name:", $11);
+
+            }
+            else {
+                printf(", %s%s\"LOG_ERROR\": \"FAILED to process: %s\"", n , indent, $0);
+            }
 
         }
         else {
-            printf(", %s%s\"LOG_ERROR\": \"FAILED to process: %s\"", n , indent, $0);
-        }
-
-    }
-    else {
-        # old way
-        if (NF > 3){
-            for(i=1; i<=NF  ; i++){
-                if(i!=3 && i!=13 && i!=17){
-                    if(i>1)
-                        printf(", %s",n);
-                    printf("%s\"%s\": \"%s\"",indent,request_log_fields[i],$i);
-                }
+            if(debug == "true"){
+                print "Line "NR" is blank, ignored."
             }
         }
-        else {
-            for(i=1; i<=NF ; i++){
-                if(i>1) {
-                    printf(", %s",n);
-                }
-                printf("%s\"%s\": \"%s\"",indent,msg_fields[i],$i);
-            }
-       }
 
+
+        printf("%s}\n", n);
     }
 
-    printf("%s}\n", n);
 
 }

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -188,17 +188,30 @@ BEGIN {
         }
     }
 }
+
+########################################################################
+#
+# Opens a json log element with kvp for time, pib and log entry type.
+#
 function print_opener(){
     printf("{ %s", n);
     printf("%s\"%stime\": %s", indent, prefix, $1);
-    printf(", %s%s\"%spid\": %s",  n, indent, prefix, $2);
-    printf(", %s%s\"%stype\": \"%s\"",  n, indent, prefix, $3);
+    write_kvp_num("pid",$2);
+    write_kvp_str("type", $3);
 }
-
+########################################################################
+#
+# Closes a json element.
+#
 function print_closer(){
     printf("%s}\n", n);
 }
 
+
+########################################################################
+#
+# Retuns the boolean state based on the passed value and the default.
+#
 function process_bool_value(var_val, dfault, ret_val){
     ret_val = dfault;
     if (length(var_val)>0) {
@@ -209,9 +222,18 @@ function process_bool_value(var_val, dfault, ret_val){
     return ret_val;
 }
 
+########################################################################
+#
+# Writes a key value pair in json. The value is handled as a number
+#
 function write_kvp_num(key,value){
     printf (", %s%s\"%s%s\": %s", n, indent, prefix, key, value);
 }
+
+########################################################################
+#
+# Writes a key value pair in json. The value handled as a string.
+#
 function write_kvp_str(key,value){
     printf (", %s%s\"%s%s\": \"%s\"", n, indent, prefix, key, value);
 }

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -68,11 +68,14 @@ BEGIN {
         # This is a logging error.
         if ( send_error=="true" ) {
             # Make an special error log entry about the error in the log format.
+            # We don't call print_opener() because it's a mess so we hack it
+            # together right here...
             printf ("{ %s%s\"%stime\": -1", n, indent, prefix);
             printf (", %s%s\"%spid\": -1", n, indent, prefix);
             printf (", %s%s\"%stype\": \"error\"", n, indent, prefix);
             msg = "OUCH! Input log line "NR" appears to use [ and ] to delimit values. Line: "$0;
-            printf (", %s%s\"%smessage\": \"%s\"} %s", n, indent, prefix, msg, n);
+            write_kvp_str("message",msg);
+            print_closer();
         }
     }
     else if($0.length() != 0) { # Don't process an empty line...

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -120,7 +120,7 @@ BEGIN {
             write_kvp_str("query_string",$13);
 
             # Field $14 always has the value "bes" and is used to indicate
-            # that the following fields orginated in the BES. It is not 
+            # that the following fields orginated in the BES. It is not
             # semantically important to NGAP
             # write_kvp_str("bes",$14);
 

--- a/builds/ngap/beslog2json.awk
+++ b/builds/ngap/beslog2json.awk
@@ -203,6 +203,7 @@ function print_opener(){
     write_kvp_num("pid",$2);
     write_kvp_str("type", $3);
 }
+
 ########################################################################
 #
 # Closes a json element.
@@ -210,7 +211,6 @@ function print_opener(){
 function print_closer(){
     printf("%s}\n", n);
 }
-
 
 ########################################################################
 #


### PR DESCRIPTION
A rewrite of the awk program that encodes a BES log file (all /var/bes/bes.log) in json.

Added awk functions to make the stamp and repeat parts of the code utilize a single source of truth. 

Added controls that allow invocations to control which BES log types will be transmitted as JSON.

Added an (optional) prefix that could be used as a namespace to help identify our application variables in the Elastic/Kibana.

Added QC code to handle incorrectly formatted log lines (what's up with that??) and to elide empty lines.

TIP: It's not a big program, but it has been massively rewritten. I suggest reviewing it by simply reading what it is now and not troubling yourself with the diff.
