### PR TITLE
Javascript mime-type change

### DIFF
--- a/builds/ngap/Dockerfile
+++ b/builds/ngap/Dockerfile
@@ -171,6 +171,11 @@ RUN set -e \
     && mv /tomcat9-server.xml ${CATALINA_HOME}/conf/server.xml \
     && chown -R tomcat:tomcat ${CATALINA_HOME}/conf/server.xml
 
+# Tweak the mime-type for javascript. (@TODO Will this satisfy X-Content-Type-Options=nosniff issues?)
+Run set -e \
+    && sed -i 's+text/javascript+application/javascript+g' ${CATALINA_HOME}/conf/web.xml
+
+
 RUN set -e \
     && echo "Cleaning up Tomcat distribution files..." >&2 \
     && rm -fv "/${TOMCAT_DISTRO}.tar.gz"  >&2


### PR DESCRIPTION
Adds to the **_ngap/Dockerfile_** a `sed` command that edits the `$CATALINA_HOME/conf/web.xml` file to change the _mime-type_  for the file extensions `.js` and `.mjs` from `text/javascript` to `application/javascript`

This change is basically a change to the Tomcat _default servlet_ configuration. I tried adding this change to the Hyrax web.xml file but it did not affect the behavior of the Tomcat _default servlet_. Go figure...