### PR TITLE
HD-109: Do not test deployed image for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ stages:
   - name: BUILD
     if:  branch = master
   - name: TEST_DEPLOYED_IMAGE
-    if: branch = master
+    if: (branch = master) and (type != pull_request)
   - name: disabled
     if: branch = disabled
 


### PR DESCRIPTION
Fix #109 by turning off regression testing on deployed images for pull requests.