### PR TITLE
Jackson 2.+ restored

### DIFF
--- a/el9-builds/build.gradle
+++ b/el9-builds/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     dependencyLibrariesDownload "org.redisson:redisson:latest.release"
 
     // The Jackson libraries
-    dependencyLibrariesDownload "com.fasterxml.jackson.core:jackson-core:2.21.+"
-    dependencyLibrariesDownload "com.fasterxml.jackson.core:jackson-annotations:2.21"
-    dependencyLibrariesDownload "com.fasterxml.jackson.core:jackson-databind:2.21.+"
+    dependencyLibrariesDownload "com.fasterxml.jackson.core:jackson-core:2.+"
+    dependencyLibrariesDownload "com.fasterxml.jackson.core:jackson-annotations:2.+"
+    dependencyLibrariesDownload "com.fasterxml.jackson.core:jackson-databind:2.+"
 
     // The Amazon ElasticCache Cluster Client
     dependencyLibrariesDownload 'com.amazonaws:elasticache-java-cluster-client:1.+'


### PR DESCRIPTION
Looks like they fixed the maven repo issues with Jackson 2.22 so onward we go.