### PR TITLE
Update versions, tags, and DOI badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Hyrax docker
 
-## Current Version: <font style="font-size: 300%;">**Hyrax-1.17.1**</font> [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14660548.svg)](https://doi.org/10.5281/zenodo.14660548)
+## Current Version: <font style="font-size: 300%;">**Hyrax-1.18.0**</font> [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21541138.svg)](https://doi.org/10.5281/zenodo.21541138)
 
-**Hyrax-1.17.1** is composed of:
+**Hyrax-1.18.0** on RHEL9 is composed of:
 
 |                                                                                    ||
 |:----------------------------------------------------------------------------------:| :---:|
-| **[OLFS version 1.18.15](https://github.com/OPENDAP/olfs/releases/tag/1.18.15)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14659391.svg)](https://doi.org/10.5281/zenodo.14659391)
-| **[BES version 3.21.1](https://github.com/OPENDAP/bes/releases/tag/3.21.1)** |[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14655683.svg)](https://doi.org/10.5281/zenodo.14655683)
-| **[libdap4 version 3.21.1](https://github.com/OPENDAP/libdap4/releases/tag/3.21.1)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14646648.svg)](https://doi.org/10.5281/zenodo.14646648)|
+| **[OLFS version 1.19.0](https://github.com/OPENDAP/olfs/releases/tag/1.19.0-1)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21540577.svg)](https://doi.org/10.5281/zenodo.21540577)|
+| **[BES version 3.22.0](https://github.com/OPENDAP/bes/releases/tag/3.22.0-0)** |[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21540512.svg)](https://doi.org/10.5281/zenodo.21540512)|
+| **[libdap4 version 3.22.0](https://github.com/OPENDAP/libdap4/releases/tag/3.22.0)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21540505.svg)](https://doi.org/10.5281/zenodo.21540505)|
 
 
 ## <a name="contents"></a>Contents

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# Hyrax docker
+# Hyrax docker [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14015000.svg)](https://doi.org/10.5281/zenodo.14015000)
 
-Current Version: **Hyrax-1.18.0** 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14015000.svg)](https://doi.org/10.5281/zenodo.14015000)
+_Current Hyrax Release Version: **Hyrax-1.18.0**_
 
 **Hyrax** is composed of
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Hyrax docker
 
-## Current Version: <font style="font-size: 300%;">**Hyrax-1.18.0**</font> [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21541138.svg)](https://doi.org/10.5281/zenodo.21541138)
+Current Version: **Hyrax-1.18.0** 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14015000.svg)](https://doi.org/10.5281/zenodo.14015000)
 
-**Hyrax-1.18.0** on RHEL9 is composed of:
-
-|                                                                                    ||
-|:----------------------------------------------------------------------------------:| :---:|
-| **[OLFS version 1.19.0](https://github.com/OPENDAP/olfs/releases/tag/1.19.0-1)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21540577.svg)](https://doi.org/10.5281/zenodo.21540577)|
-| **[BES version 3.22.0](https://github.com/OPENDAP/bes/releases/tag/3.22.0-0)** |[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21540512.svg)](https://doi.org/10.5281/zenodo.21540512)|
-| **[libdap4 version 3.22.0](https://github.com/OPENDAP/libdap4/releases/tag/3.22.0)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21540505.svg)](https://doi.org/10.5281/zenodo.21540505)|
-
+**Hyrax** is composed of
+* **[OLFS](https://github.com/OPENDAP/olfs/releases/latest)** [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1125140.svg)](https://doi.org/10.5281/zenodo.1125140)
+* **[BES](https://github.com/OPENDAP/bes/releases/latest)** [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1013917.svg)](https://doi.org/10.5281/zenodo.1013917)
+* **[libdap4](https://github.com/OPENDAP/libdap4/releases/latest)** [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1013914.svg)](https://doi.org/10.5281/zenodo.1013914)
 
 ## <a name="contents"></a>Contents
 * [Overview](#overview)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ Current Version: **Hyrax-1.18.0**
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14015000.svg)](https://doi.org/10.5281/zenodo.14015000)
 
 **Hyrax** is composed of
-* **[OLFS](https://github.com/OPENDAP/olfs/releases/latest)** [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1125140.svg)](https://doi.org/10.5281/zenodo.1125140)
-* **[BES](https://github.com/OPENDAP/bes/releases/latest)** [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1013917.svg)](https://doi.org/10.5281/zenodo.1013917)
-* **[libdap4](https://github.com/OPENDAP/libdap4/releases/latest)** [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1013914.svg)](https://doi.org/10.5281/zenodo.1013914)
+
+| | |
+| ---: | :---: |
+| **[OLFS](https://github.com/OPENDAP/olfs/releases/latest)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1125140.svg)](https://doi.org/10.5281/zenodo.1125140) |
+| **[BES](https://github.com/OPENDAP/bes/releases/latest)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1013917.svg)](https://doi.org/10.5281/zenodo.1013917) |
+| **[libdap4](https://github.com/OPENDAP/libdap4/releases/latest)** | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1013914.svg)](https://doi.org/10.5281/zenodo.1013914) |
 
 ## <a name="contents"></a>Contents
 * [Overview](#overview)


### PR DESCRIPTION
I updated the README file to represent `Hyrax-1.18.0 on RHEL9`. I can instead make it to Hyrax-1.18.0 on RHEL8  